### PR TITLE
Unset JAVA_HOME.

### DIFF
--- a/snap/local/script-wrapper.bash
+++ b/snap/local/script-wrapper.bash
@@ -3,5 +3,6 @@
 set -eu
 
 export PATH=$SNAP/usr/lib/jvm/default-java/bin:$PATH
+unset JAVA_HOME
 
 $SNAP/opt/kafka/bin/$_wrapper_script "$@"


### PR DESCRIPTION
This fixes an issue with the kafka-run-class.sh script where it may pick
up a JAVA_HOME from the user's environment, causing the wrong java to be
used to run kafka.