### PR TITLE
Add stop hook.

### DIFF
--- a/charm/kafka/reactive/kafka.py
+++ b/charm/kafka/reactive/kafka.py
@@ -34,6 +34,14 @@ def upgrade():
     install_snap()
 
 
+@hook('stop')
+def uninstall():
+    try:
+        check_call(['snap', 'remove', 'kafka'])
+    except subprocess.CalledProcessError as e:
+        hookenv.log("failed to remove snap: {}".format(e))
+
+
 def install_snap():
     snap_file = get_snap_file_from_charm()
     if not snap_file:


### PR DESCRIPTION
This uninstalls the kafka snap during the stop hook. Stopping the
service and removing the software ensures that no processes are left
running that could hold on to a mounted volume, if storage were
attached. This also ensures that the software is cleaned up in case the
charm was co-located onto a machine with other workloads.