### PR TITLE
Remove xenial series from charm.

### DIFF
--- a/charm/kafka/metadata.yaml
+++ b/charm/kafka/metadata.yaml
@@ -26,7 +26,6 @@ requires:
     interface: zookeeper
 min-juju-version: "2.4.0"
 series:
-- xenial
 - bionic
 storage:
   logs:


### PR DESCRIPTION
xenial could be supported, but we'll standardize on bionic unless there
is some reason to deploy onto xenial.