### PR TITLE
Update kafka version to 2.2.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 It's a snap. It's a charm. It's a schnapp.
 
-This project compiles Kafka 2.1.0 from source into a snap and embeds that into
+This project compiles Kafka 2.2.1 from source into a snap and embeds that into
 a charm that then operates it. Because the snap is installed locally, there is
 no concern over auto-upgrades in snaps.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: kafka
 base: core18
-version: '2.1.0'
+version: '2.2.1'
 summary: Apache Kafka is a distributed streaming platform
 description: |
     Kafka is generally used for two broad classes of applications:
@@ -73,7 +73,7 @@ parts:
     plugin: nil
     source: https://github.com/apache/kafka.git
     source-depth: 1
-    source-tag: 2.1.0
+    source-tag: 2.2.1
     override-build: |-
       export PATH=$(pwd)/../../deps/build/gradle-5.1.1/bin:$PATH
       gradle
@@ -86,7 +86,7 @@ parts:
     - gradle
     plugin: nil
     override-build: |-
-      tarball=$(pwd)/../../gradle/build/core/build/distributions/kafka_2.11-2.1.0.tgz
+      tarball=$(pwd)/../../gradle/build/core/build/distributions/kafka_2.12-2.2.1.tgz
       mkdir -p $SNAPCRAFT_PART_INSTALL/opt/kafka
       (cd $SNAPCRAFT_PART_INSTALL/opt/kafka; tar --strip-components=1 -xzvf $tarball)
     stage:


### PR DESCRIPTION
Kafka 2.1.0 can suffer from connection leak issues (source needed?) which seem to be fixed in 2.2.1.