### PR TITLE
Support rolling upgrades of Kafka brokers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: snap lint charm
 
 .PHONY: lint
 lint:
-	flake8 --ignore=E121,E123,E126,E226,E24,E704,E265 charm/kafka
+	flake8 --ignore=E121,E123,E126,E226,E24,E704,E265 charm/kafka charm/kafka/actions/*
 
 .PHONY: schnapp
 schnapp: snap fat-charm

--- a/charm/kafka/actions.yaml
+++ b/charm/kafka/actions.yaml
@@ -53,3 +53,7 @@ write-topic:
       description: Data to write to topic
   required: [topic, data]
   additionalProperties: false
+upgrade-kafka:
+  description: Upgrade kafka installation
+show-upgrade:
+  description: Upgrade kafka installation

--- a/charm/kafka/actions/alter-topic
+++ b/charm/kafka/actions/alter-topic
@@ -15,15 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import kafkautils
 import subprocess
 
-from pathlib import Path
-
 from charmhelpers.core import hookenv, host
 from charms.reactive import is_state
-from charms.layer.kafka import KAFKA_SERVICE
+from charms.layer.kafka import KAFKA_SERVICE, keystore_password
 
 
 if not is_state('kafka.started'):
@@ -35,9 +32,10 @@ topic_name = hookenv.action_get('topic')
 topic_partitions = hookenv.action_get('partitions')
 
 # Create the topic if kafka is running
-if host.service_available(KAFKA_SERVICE) and host.service_running(KAFKA_SERVICE):
+if host.service_available(KAFKA_SERVICE) \
+        and host.service_running(KAFKA_SERVICE):
     zookeepers = kafkautils.get_zookeepers()
-    password = keystore_pass()
+    password = keystore_password()
     try:
         output = subprocess.check_call(['/snap/bin/kafka.topics',
                                         '--zookeeper', zookeepers, '--alter',

--- a/charm/kafka/actions/create-topic
+++ b/charm/kafka/actions/create-topic
@@ -34,14 +34,16 @@ topic_partitions = hookenv.action_get('partitions')
 topic_replication = hookenv.action_get('replication')
 
 # Create the topic if kafka is running
-if host.service_available(KAFKA_SERVICE) and host.service_running(KAFKA_SERVICE):
+if host.service_available(KAFKA_SERVICE) \
+        and host.service_running(KAFKA_SERVICE):
     zookeepers = kafkautils.get_zookeepers()
     try:
         output = subprocess.check_call(['/snap/bin/kafka.topics',
-                        '--zookeeper', zookeepers, '--create',
-                        '--topic', topic_name,
-                        '--partitions', str(topic_partitions),
-                        '--replication-factor', str(topic_replication)])
+                                        '--zookeeper', zookeepers, '--create',
+                                        '--topic', topic_name,
+                                        '--partitions', str(topic_partitions),
+                                        '--replication-factor',
+                                        str(topic_replication)])
     except subprocess.CalledProcessError as e:
         kafkautils.fail('Kafka command failed: {}'.format(e.output))
     else:

--- a/charm/kafka/actions/list-topics
+++ b/charm/kafka/actions/list-topics
@@ -29,11 +29,12 @@ if not is_state('kafka.started'):
 
 
 # List topics if kafka is running
-if host.service_available(KAFKA_SERVICE) and host.service_running(KAFKA_SERVICE):
+if host.service_available(KAFKA_SERVICE) \
+        and host.service_running(KAFKA_SERVICE):
     zookeepers = kafkautils.get_zookeepers()
     try:
         output = subprocess.check_output(['/snap/bin/kafka.topics',
-                        '--zookeeper', zookeepers, '--list'])
+                                          '--zookeeper', zookeepers, '--list'])
     except subprocess.CalledProcessError as e:
         kafkautils.fail('Kafka command failed: {}'.format(e.output))
     else:

--- a/charm/kafka/actions/list-zks
+++ b/charm/kafka/actions/list-zks
@@ -28,7 +28,8 @@ if not is_state('kafka.started'):
 
 
 # List zookeepers if kafka is running
-if host.service_available(KAFKA_SERVICE) and host.service_running(KAFKA_SERVICE):
+if host.service_available(KAFKA_SERVICE) \
+        and host.service_running(KAFKA_SERVICE):
     zookeepers = kafkautils.get_zookeepers()
     if zookeepers:
         hookenv.action_set({'raw': zookeepers})

--- a/charm/kafka/actions/read-topic
+++ b/charm/kafka/actions/read-topic
@@ -35,18 +35,20 @@ topic_partition = hookenv.action_get('partition')
 ssl_properties = os.path.join(KAFKA_SNAP_DATA, 'client-ssl.properties')
 
 # Read the topic if kafka is running
-if host.service_available(KAFKA_SERVICE) and host.service_running(KAFKA_SERVICE):
+if host.service_available(KAFKA_SERVICE) \
+        and host.service_running(KAFKA_SERVICE):
     host = subprocess.check_output(['hostname', '-s']).decode('utf8').strip()
     port = KAFKA_PORT
     zookeepers = kafkautils.get_zookeepers()
     try:
         output = subprocess.check_output(['/snap/bin/kafka.console-consumer',
-                              '--bootstrap-server', '{}:{}'.format(host, port),
-                              '--topic', topic_name,
-                              '--partition', str(topic_partition),
-                              '--from-beginning',
-                              '--timeout-ms', '1000',
-                              '--consumer.config', ssl_properties])
+                                          '--bootstrap-server',
+                                          '{}:{}'.format(host, port),
+                                          '--topic', topic_name,
+                                          '--partition', str(topic_partition),
+                                          '--from-beginning',
+                                          '--timeout-ms', '1000',
+                                          '--consumer.config', ssl_properties])
     except subprocess.CalledProcessError as e:
         kafkautils.fail('Kafka command failed: {}'.format(e.output))
     else:

--- a/charm/kafka/actions/show-upgrade
+++ b/charm/kafka/actions/show-upgrade
@@ -1,0 +1,49 @@
+#!/usr/local/sbin/charm-env python3
+
+import kafkautils
+
+import re
+import subprocess
+import yaml
+
+from charmhelpers.core import hookenv
+
+from charms.layer import snap
+
+
+result = {}
+
+# Add installed snap version
+try:
+    snap_info_yaml = subprocess.check_output(['snap', 'info', 'kafka'])
+    snap_info = yaml.load(snap_info_yaml, Loader=yaml.SafeLoader)
+    result['installed'] = snap_info.get('installed')
+    if result['installed']:
+        result['installed'] = re.sub(' .*', '', result['installed'])
+except Exception as e:
+    kafkautils.fail('failed to get installed package version: '
+                    '{}'.format(e.output))
+
+# Add available upgrade snap version
+try:
+    snap_file = snap._resource_get('kafka')
+    if not snap_file:
+        result['available'] = None
+    else:
+        snap_info_yaml = subprocess.check_output(['snap', 'info', snap_file])
+        snap_info = yaml.load(snap_info_yaml, Loader=yaml.SafeLoader)
+        result['available'] = snap_info.get('version')
+        if result['available']:
+            result['available'] = re.sub(' .*', '', result['available'])
+except Exception as e:
+    kafkautils.fail('failed to get available package version: '
+                    '{}'.format(e.output))
+
+# Add relevant config options
+cfg = hookenv.config()
+result['inter-broker-protocol-version'] = \
+        cfg.get('inter_broker_protocol_version')
+result['log-message-format-version'] = \
+        cfg.get('log_message_format_version')
+
+hookenv.action_set(result)

--- a/charm/kafka/actions/smoke-test
+++ b/charm/kafka/actions/smoke-test
@@ -35,7 +35,8 @@ topic_partitions = "1"
 topic_replication = "1"
 
 # Smoke only when kafka is running
-if host.service_available(KAFKA_SERVICE) and host.service_running(KAFKA_SERVICE):
+if host.service_available(KAFKA_SERVICE) \
+        and host.service_running(KAFKA_SERVICE):
     # List ZKs
     zookeepers = kafkautils.get_zookeepers()
     if not zookeepers:
@@ -44,17 +45,17 @@ if host.service_available(KAFKA_SERVICE) and host.service_running(KAFKA_SERVICE)
     # Create a topic
     try:
         subprocess.check_call(['/snap/bin/kafka.topics',
-                        '--zookeeper', zookeepers, '--create',
-                        '--topic', topic_name,
-                        '--partitions', topic_partitions,
-                        '--replication-factor', topic_replication])
+                               '--zookeeper', zookeepers, '--create',
+                               '--topic', topic_name,
+                               '--partitions', topic_partitions,
+                               '--replication-factor', topic_replication])
     except subprocess.CalledProcessError as e:
         kafkautils.fail('Kafka command failed: {}'.format(e.output))
 
     # List topics
     try:
         subprocess.check_call(['/snap/bin/kafka.topics',
-                        '--zookeeper', zookeepers, '--list'])
+                               '--zookeeper', zookeepers, '--list'])
     except subprocess.CalledProcessError as e:
         kafkautils.fail('Kafka command failed: {}'.format(e.output))
 

--- a/charm/kafka/actions/upgrade-kafka
+++ b/charm/kafka/actions/upgrade-kafka
@@ -1,0 +1,22 @@
+#!/usr/local/sbin/charm-env python3
+
+import kafkautils
+
+from charmhelpers.core import hookenv
+
+from charms.reactive import remove_state
+
+from charms.layer import snap
+
+
+if not hookenv.config().get('inter_broker_protocol_version'):
+    kafkautils.fail('inter_broker_protocol_version not configured')
+
+remove_state('kafka.nrpe_helper.installed')
+remove_state('kafka.started')
+remove_state('snap.installed.kafka')
+
+snap.install('kafka')
+snap.connect('kafka:removable-media', 'core:removable-media')
+
+hookenv.action_set({'outcome': 'success'})

--- a/charm/kafka/actions/write-topic
+++ b/charm/kafka/actions/write-topic
@@ -35,16 +35,18 @@ data = hookenv.action_get('data')
 ssl_properties = os.path.join(KAFKA_SNAP_DATA, 'client-ssl.properties')
 
 # Write to the topic if kafka is running
-if host.service_available(KAFKA_SERVICE) and host.service_running(KAFKA_SERVICE):
+if host.service_available(KAFKA_SERVICE) \
+        and host.service_running(KAFKA_SERVICE):
     host = subprocess.check_output(['hostname', '-s']).decode('utf8').strip()
     port = KAFKA_PORT
     zookeepers = kafkautils.get_zookeepers()
     try:
         output = subprocess.check_output(['/snap/bin/kafka.console-producer',
-                              '--broker-list', '{}:{}'.format(host, port),
-                              '--topic', topic_name,
-                              '--producer.config', ssl_properties],
-                              input=bytes(data, 'UTF-8'))
+                                          '--broker-list',
+                                          '{}:{}'.format(host, port),
+                                          '--topic', topic_name,
+                                          '--producer.config', ssl_properties],
+                                         input=bytes(data, 'UTF-8'))
     except subprocess.CalledProcessError as e:
         kafkautils.fail('Kafka command failed: {}'.format(e.output))
     else:

--- a/charm/kafka/config.yaml
+++ b/charm/kafka/config.yaml
@@ -89,3 +89,17 @@ options:
     default: '.10'
     description: |-
       The critical threshold for average idle percentage of a network processor
+  inter_broker_protocol_version:
+    type: string
+    default: ''
+    description: |-
+      Specify the message format version the broker will use to append messages
+      to the logs. If set to empty string, the current broker version is used. This
+      setting is useful for coordinating kafka broker upgrades.
+  log_message_format_version:
+    type: string
+    default: ''
+    description: |-
+      Specify the message format version the broker will use to append messages
+      to the logs. If set to empty string, the current broker version is used. This
+      setting is useful for coordinating kafka broker upgrades.

--- a/charm/kafka/config.yaml
+++ b/charm/kafka/config.yaml
@@ -22,6 +22,11 @@ options:
     description: |-
       Contents of a custom log4j.properties file for the Kafka brokers. If
       empty, the default will be used instead.
+  kafka_heap_opts:
+    default: "-Xmx8G -Xms8G"
+    type: string
+    description: |-
+      Kafka broker JVM heap options
 
   # TLS options
   subject_alt_names:

--- a/charm/kafka/layer.yaml
+++ b/charm/kafka/layer.yaml
@@ -15,8 +15,6 @@ options:
     include_system_packages: True
   snap:
     core: {}
-    kafka:
-      channel: beta
-      connect:
-      - ['kafka:removable-media', 'core:removable-media']
+    # Do not include the kafka snap here; charm needs to override behavior to
+    # manage rolling upgrades.
 repo: https://github.com/cloud-green/kafka-snap-charm.git

--- a/charm/kafka/lib/charms/layer/kafka.py
+++ b/charm/kafka/lib/charms/layer/kafka.py
@@ -131,6 +131,16 @@ class Kafka(object):
             context=context
         )
 
+        render(
+            source='broker.env',
+            target=os.path.join(KAFKA_SNAP_DATA, 'broker.env'),
+            owner='root',
+            perms=0o644,
+            context={
+                'kafka_heap_opts': config.get('kafka_heap_opts', ''),
+            }
+        )
+
         log4j_file = os.path.join(KAFKA_SNAP_DATA, 'log4j.properties')
         if config.get('log4j_properties'):
             with open(log4j_file, 'w') as f:

--- a/charm/kafka/lib/charms/layer/kafka.py
+++ b/charm/kafka/lib/charms/layer/kafka.py
@@ -109,6 +109,10 @@ class Kafka(object):
             'auto_create_topics': config['auto_create_topics'],
             'default_partitions': config['default_partitions'],
             'default_replication_factor': config['default_replication_factor'],
+            'inter_broker_protocol_version':
+                config.get('inter_broker_protocol_version'),
+            'log_message_format_version':
+                config.get('log_message_format_version'),
         }
 
         render(

--- a/charm/kafka/reactive/kafka.py
+++ b/charm/kafka/reactive/kafka.py
@@ -15,11 +15,19 @@
 
 from charms.layer.kafka import Kafka, KAFKA_PORT
 
+from charms.layer import snap
+
 from charmhelpers.core import hookenv, unitdata
 
-from charms.reactive import (when, when_not, hook,
+from charms.reactive import (when, when_not,
                              remove_state, set_state)
 from charms.reactive.helpers import data_changed
+
+
+@when_not('snap.installed.kafka')
+def install_kafka():
+    snap.install('kafka')
+    snap.connect('kafka:removable-media', 'core:removable-media')
 
 
 @when('snap.installed.kafka')
@@ -32,12 +40,6 @@ def waiting_for_zookeeper():
 @when_not('kafka.started', 'zookeeper.ready')
 def waiting_for_zookeeper_ready(zk):
     hookenv.status_set('waiting', 'waiting for zookeeper to become ready')
-
-
-@hook('upgrade-charm')
-def upgrade_charm():
-    remove_state('kafka.nrpe_helper.installed')
-    remove_state('kafka.started')
 
 
 @when_not(

--- a/charm/kafka/templates/broker.env
+++ b/charm/kafka/templates/broker.env
@@ -1,0 +1,1 @@
+export KAFKA_HEAP_OPTS="{{ kafka_heap_opts }}"

--- a/charm/kafka/templates/server.properties
+++ b/charm/kafka/templates/server.properties
@@ -149,3 +149,11 @@ group.initial.rebalance.delay.ms=0
 # Enable auto creation of topics on the server
 auto.create.topics.enable={{ auto_create_topics|lower }}
 
+{% if inter_broker_protocol_version -%}
+inter.broker.protocol.version={{ inter_broker_protocol_version }}
+{%- endif %}
+
+{% if log_message_format_version -%}
+log.message.format.version={{ log_message_format_version }}
+{%- endif %}
+

--- a/snap/local/start-kafka-wrapper.bash
+++ b/snap/local/start-kafka-wrapper.bash
@@ -22,4 +22,8 @@ export KAFKA_JMX_OPTS="-Djava.rmi.server.hostname=localhost \
 -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false
 -Dcom.sun.management.jmxremote.ssl=false"
 
+if [ -e "$SNAP_COMMON/broker.env" ]; then
+    . $SNAP_COMMON/broker.env
+fi
+
 $SNAP/opt/kafka/bin/kafka-server-start.sh $SNAP_COMMON/server.properties


### PR DESCRIPTION
In order to upgrade a Kafka cluster, one must:

1. Set the broker API compatibility version to the current installed
Kafka version.
2. Upgrade each Kafka broker one by one.
3. Once all brokers are upgrades, set the broker API compatibility
version to the newly installed version.

Juju cannot accomplish this with an upgrade-charm hook. This change
makes the upgrade-charm hook a no-op, replacing it with an action that
can individually upgrade each broker unit. Additionally, config options
are added to control the broker API compatibility level.

A show-upgrade action displays the currently installed version,
to-be-upgraded available version, and relevant log format/protocol
version config options, useful to confirm actual workload state before
proceeding with an upgrade.