### PR TITLE
Update to Kafka 2.4.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 It's a snap. It's a charm. It's a schnapp.
 
-This project compiles Kafka 2.2.1 from source into a snap and embeds that into
+This project compiles Kafka from source into a snap and embeds that into
 a charm that then operates it. Because the snap is installed locally, there is
 no concern over auto-upgrades in snaps.
 
@@ -13,21 +13,10 @@ no concern over auto-upgrades in snaps.
 
 Will build the Kafka snap, and then the charm in `charm/builds/kafka`.
 
-# Operating
+# Quick start
 
-This charm does not require any configuration. It relates to zookeeper and
-scales horizontally by adding units. It supports Juju storage.
-
-The snap uses strict confinement with the removable-media plug to support
-storage.
-
-    juju deploy ./charm/builds/kafka
-    juju deploy zookeeper
-    juju relate kafka zookeeper
-
-The charm also supports storage:
-
-    juju add-storage kafka/0 logs=1G
+    cd charm
+    juju deploy ./bundle.yaml
 
 # Notes
 

--- a/charm/bundle.yaml
+++ b/charm/bundle.yaml
@@ -9,7 +9,7 @@ applications:
       nagios_servicegroups: webops-prompt-critical,prod-event-bus-ua
     constraints: mem=16G cores=4 root-disk=20G
     resources:
-      kafka: ../kafka_2.2.1_amd64.snap
+      kafka: ../kafka_2.4.0_amd64.snap
     storage:
       logs: rootfs,10G
   zk:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: kafka
 base: core18
-version: '2.2.1'
+version: '2.4.0'
 summary: Apache Kafka is a distributed streaming platform
 description: |
     Kafka is generally used for two broad classes of applications:
@@ -77,7 +77,7 @@ parts:
     plugin: nil
     source: https://github.com/apache/kafka.git
     source-depth: 1
-    source-tag: 2.2.1
+    source-tag: 2.4.0
     override-build: |-
       export PATH=$(pwd)/../../deps/build/gradle-5.1.1/bin:$PATH
       gradle
@@ -90,7 +90,7 @@ parts:
     - gradle
     plugin: nil
     override-build: |-
-      tarball=$(pwd)/../../gradle/build/core/build/distributions/kafka_2.12-2.2.1.tgz
+      tarball=$(pwd)/../../gradle/build/core/build/distributions/kafka_2.12-2.4.0.tgz
       mkdir -p $SNAPCRAFT_PART_INSTALL/opt/kafka
       (cd $SNAPCRAFT_PART_INSTALL/opt/kafka; tar --strip-components=1 -xzvf $tarball)
     stage:


### PR DESCRIPTION
Update snap to build Kafka 2.4.0. Corrected/simplified README.