### PR TITLE
Add systemd override to increase fd limit. Fix snap build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: snap lint charm
 
 .PHONY: lint
 lint:
-	flake8 --ignore=E121,E123,E126,E226,E24,E704,E265 charm/kafka charm/kafka/actions/*
+	flake8 --ignore=E121,E123,E126,E226,E24,E704,E265,E501 charm/kafka charm/kafka/actions/*
 
 .PHONY: schnapp
 schnapp: snap fat-charm

--- a/charm/kafka/lib/charms/layer/kafka.py
+++ b/charm/kafka/lib/charms/layer/kafka.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import re
 import socket
+from subprocess import check_call
 
 from pathlib import Path
 from base64 import b64encode
@@ -172,6 +173,15 @@ class Kafka(object):
                 'kafka_heap_opts': config.get('kafka_heap_opts', ''),
             }
         )
+
+        render(
+            source='override.conf',
+            target='/etc/systemd/system/snap.kafka.kafka.service.d/override.conf',
+            owner='root',
+            perms=0o644,
+            context={},
+        )
+        check_call(['systemctl', 'daemon-reload'], universal_newlines=True)
 
         log4j_file = os.path.join(KAFKA_SNAP_DATA, 'log4j.properties')
         if config.get('log4j_properties'):

--- a/charm/kafka/templates/override.conf
+++ b/charm/kafka/templates/override.conf
@@ -1,0 +1,4 @@
+[Service]
+LimitNOFILE=100000
+Restart=on-failure
+RestartSec=1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,6 +66,7 @@ parts:
     - default-jdk-headless
     - unzip
     - wget
+    - curl
     plugin: nil
     override-build: |-
       # NOTE: snapcraft gradle plugin currently does not work with kafka build


### PR DESCRIPTION
Adding a systemd override for the snap kafka service to raise the file
descriptor limit and set a restart policy.

Apparently curl isn't installed in the snap build environment
automatically anymore, so added to build-packages.